### PR TITLE
bugfix: off-by-one error when calling originalPositionFor

### DIFF
--- a/src/lib/applySourceMapsForProfile.mjs
+++ b/src/lib/applySourceMapsForProfile.mjs
@@ -99,8 +99,8 @@ async function resolveTracesForUrlAssets(traces) {
       resolveOriginalLocations(
         url,
         traces.map((traceable) => ({
-          column: Math.max(0, traceable.columnNumber - 1),
-          line: Math.max(1, traceable.lineNumber),
+          column: traceable.columnNumber,
+          line: traceable.lineNumber
         }))
       ).then((resolvedLocations) => {
         resolvedLocations.forEach((resolvedLocation, i) => {

--- a/src/lib/resolveOriginalLocations.mjs
+++ b/src/lib/resolveOriginalLocations.mjs
@@ -106,8 +106,8 @@ export const resolveOriginalLocations = async (url, locations, fileLoader) => {
 
     locations.forEach(({ column, line }) => {
       const originalPosition = consumer.originalPositionFor({
-        line: line || 1,
-        column: Math.max(0, column - 1),
+        line: (line ?? 0) + 1,
+        column: column ?? 0,
       });
       let source = originalPosition.source || "";
       const isRelative = source.startsWith("..");
@@ -117,6 +117,7 @@ export const resolveOriginalLocations = async (url, locations, fileLoader) => {
       if (isRelative) {
         source = path.resolve(path.dirname(url), source);
       }
+      originalPosition.line = originalPosition.line == null ? null : originalPosition.line -1
       resolvedLocations.push({
         ...originalPosition,
         source,


### PR DESCRIPTION
👋  @jantimon!

First time contribution here. I have stumbled upon this bug during my day job at [SUSE](https://www.suse.com/) for [Rancher](https://www.rancher.com/).

Origin of the problem is:

- Traces encode both line and column numbers as 0-based
- Source maps encode both line and column numbers as 0-based (https://sourcemaps.info/spec.html)

*But* `source-map`'s `originalPositionFor` method makes a different assumption! Specifically:

 - columns are 0-based (like everything else, good) but
 - rows are 1-based (surprising!!!)

https://github.com/mozilla/source-map/blob/b2ddafebdb7f069fee7e24d76846242fdd840fd5/README.md#sourcemapconsumerprototypeoriginalpositionforgeneratedposition

This patch changes arguments to `originalPositionFor` and returned values from it to isolate its "special behavior" and allow the rest of the program to assume all coordinates are 0-based.

This addressed a problem where names were not correctly decoded in some of our traces.

I hope this helps!