### PR TITLE
HACK: tolerate files with more than one sourceMappingURL line

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -8037,10 +8037,17 @@ async function getSourceMap(url, fileLoader) {
     console.warn(`Could not resolve "${url}".`);
     return "";
   };
-  const content = await urlLoader(url);
+  let content = await urlLoader(url);
   if (!content) {
     return;
   }
+
+  // HACK: avoid multiple source mapping URLs per content. Only keep the last, instead of keeping the first
+  const commentCount = (content.match(/\/\/# sourceMappingURL=/g) || []).length
+  for(let i = 0; i < commentCount -1; i++) {
+    content = content.replace("//# sourceMappingURL=", "//# sourceMappingDISABLED=")
+  }
+
   return new Promise((resolve, reject) => {
     source_map_resolve.resolve(
       content,

--- a/src/lib/resolveOriginalLocations.mjs
+++ b/src/lib/resolveOriginalLocations.mjs
@@ -46,10 +46,17 @@ async function getSourceMap(url, fileLoader) {
     console.warn(`Could not resolve "${url}".`);
     return "";
   };
-  const content = await urlLoader(url);
+  let content = await urlLoader(url);
   if (!content) {
     return;
   }
+
+  // HACK: avoid multiple source mapping URLs per content. Only keep the last, instead of keeping the first
+  const commentCount = (content.match(/\/\/# sourceMappingURL=/g) || []).length
+  for(let i = 0; i < commentCount -1; i++) {
+    content = content.replace("//# sourceMappingURL=", "//# sourceMappingDISABLED=")
+  }
+
   return new Promise((resolve, reject) => {
     sourceMapResolve.resolve(
       content,


### PR DESCRIPTION
Javascript files may have "sourceMappingURL" as part of their source (eg. in a string). This is explicitly not supported by the now-deprecated source-map-resolve module:

"So why is source-map-resolve deprecated? Well, source-map-resolve tries to work with source maps completely in general – support every feature and be completely language agnostic. That is a cool goal, but has a couple of flaws:
- Finding source map comments. This is done via regex to support any language, but in reality you need to know the language to know what a comment is, as opposed to something that looks like a comment inside a string."
https://github.com/lydell/source-map-resolve

source-map-resolve will take the first match, but if more than one exists, usually the one last will be correct.

This is a workaround for that case.

cc @jantimon 